### PR TITLE
Release 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,14 +453,14 @@ dependencies = [
 
 [[package]]
 name = "iscc-ffi"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "iscc-lib",
 ]
 
 [[package]]
 name = "iscc-jni"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "iscc-lib",
  "jni",
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "iscc-lib"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "blake3",
  "criterion",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "iscc-napi"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "iscc-lib",
  "napi",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "iscc-py"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "iscc-lib",
  "pyo3",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "iscc-wasm"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "hex",
  "iscc-lib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Titusz Pan <tp@py7.de>"]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ npm install @iscc/lib
 <dependency>
   <groupId>io.iscc</groupId>
   <artifactId>iscc-lib</artifactId>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
 </dependency>
 ```
 

--- a/crates/iscc-jni/README.md
+++ b/crates/iscc-jni/README.md
@@ -22,7 +22,7 @@ to create a composite identifier that exhibits similarity-preserving properties 
 <dependency>
   <groupId>io.iscc</groupId>
   <artifactId>iscc-lib</artifactId>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
 </dependency>
 ```
 

--- a/crates/iscc-jni/java/pom.xml
+++ b/crates/iscc-jni/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.iscc</groupId>
     <artifactId>iscc-lib</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <packaging>jar</packaging>
 
     <name>iscc-lib</name>

--- a/crates/iscc-napi/package.json
+++ b/crates/iscc-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iscc/lib",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/docs/howto/java.md
+++ b/docs/howto/java.md
@@ -20,7 +20,7 @@ Add the Maven dependency to your `pom.xml`:
 <dependency>
   <groupId>io.iscc</groupId>
   <artifactId>iscc-lib</artifactId>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
 </dependency>
 ```
 

--- a/docs/java-api.md
+++ b/docs/java-api.md
@@ -17,14 +17,14 @@ static methods on the `IsccLib` class. The native library is loaded automaticall
     <dependency>
       <groupId>io.iscc</groupId>
       <artifactId>iscc-lib</artifactId>
-      <version>0.0.2</version>
+      <version>0.0.3</version>
     </dependency>
     ```
 
 === "Gradle"
 
     ```groovy
-    implementation 'io.iscc:iscc-lib:0.0.2'
+    implementation 'io.iscc:iscc-lib:0.0.3'
     ```
 
 ## Quick Example

--- a/mise.toml
+++ b/mise.toml
@@ -76,7 +76,7 @@ uv run pytest
 
 [tasks."test:install"]
 description = "Test published packages are installable from registries"
-run = "uv run scripts/test_install.py {{arg(name='flags', i=0, default='--version 0.0.2')}}"
+run = "uv run scripts/test_install.py {{arg(name='flags', i=0, default='--version 0.0.3')}}"
 
 # --- Version ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iscc-lib"
-version = "0.0.2"
+version = "0.0.3"
 requires-python = ">=3.10"
 dependencies = []
 

--- a/scripts/test_install.py
+++ b/scripts/test_install.py
@@ -11,7 +11,7 @@ Usage:
     uv run scripts/test_install.py --crates     # Test crates.io only
     uv run scripts/test_install.py --go         # Test Go module only
     uv run scripts/test_install.py --maven      # Test Maven Central only
-    uv run scripts/test_install.py --version 0.0.2  # Test specific version
+    uv run scripts/test_install.py --version 0.0.3  # Test specific version
 """
 
 from __future__ import annotations
@@ -470,7 +470,7 @@ def main() -> int:
 
     # Check registry availability first
     if args.check_only or test_all:
-        v = version or "0.0.2"
+        v = version or "0.0.3"
         print("--- Registry availability ---")
         available = check_registry_availability(v)
         for reg, avail in available.items():

--- a/uv.lock
+++ b/uv.lock
@@ -500,7 +500,7 @@ wheels = [
 
 [[package]]
 name = "iscc-lib"
-version = "0.0.2"
+version = "0.0.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Release 0.0.3

Version bump and manifest sync for release 0.0.3.

Publishes to: crates.io, PyPI, npm (@iscc/lib, @iscc/wasm), Maven Central.